### PR TITLE
Test/GitHub actions vsoch

### DIFF
--- a/.github/workflows/generate-cred.yml
+++ b/.github/workflows/generate-cred.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v1
       - name: Run SourceCred
-        uses: vsoch/cred-action@0ad9320c8cfa7d6128b8a25dce283eeefff62b6d
+        uses: vsoch/cred-action@895a8b964fe40272113f5428bbac3c05ea5bbfc1
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/generate-cred.yml
+++ b/.github/workflows/generate-cred.yml
@@ -1,7 +1,6 @@
 name: generate-cred
 
 on:
-  pull_request: []
   schedule:
     # Nightly at 2:30am 
     - cron: 30 2 * * *
@@ -14,7 +13,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v1
       - name: Run SourceCred
-        uses: vsoch/cred-action@master
+        uses: vsoch/cred-action@24f61d6f9ba427bddbb31be1bc0969c7cc540bfb
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/generate-cred.yml
+++ b/.github/workflows/generate-cred.yml
@@ -1,6 +1,7 @@
 name: generate-cred
 
 on:
+  pull_request: []
   schedule:
     # Nightly at 2:30am 
     - cron: 30 2 * * *
@@ -13,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v1
       - name: Run SourceCred
-        uses: vsoch/cred-action@24f61d6f9ba427bddbb31be1bc0969c7cc540bfb
+        uses: vsoch/cred-action@7bc8a0f6ad98136ab2cf04dc078a0e10632dc3e1
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/generate-cred.yml
+++ b/.github/workflows/generate-cred.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v1
       - name: Run SourceCred
-        uses: vsoch/cred-action@7bc8a0f6ad98136ab2cf04dc078a0e10632dc3e1
+        uses: vsoch/cred-action@0ad9320c8cfa7d6128b8a25dce283eeefff62b6d
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This will test the changes done on [this branch](https://github.com/vsoch/cred-action/tree/remove-double-load) to not have a project id loaded as a GitHub alias, but to rely on the GitHub project-file. I likely fussed up the commit history at some point with a merge commit, given the commit history. Oy.